### PR TITLE
fix: KeyError: 'cw'

### DIFF
--- a/pleroma_bot/cli.py
+++ b/pleroma_bot/cli.py
@@ -692,7 +692,7 @@ def main():
                             tweet["polls"],
                             tweet["possibly_sensitive"],
                             tweets_to_post["media_processed"],
-                            cw=tweet["cw"]
+                            cw=tweet.get("cw")
                         )
                         posted[tweet["id"]] = post_id
                         posts_ids = user.posts_ids


### PR DESCRIPTION
Key 'cw' is not guaranteed in some cases, where `KeyError` exception is raised. The PR changes key access method to `dict.get()` so no exceptions are raised in these cases.
